### PR TITLE
streams2 working with node 0.10 & 0.12

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,7 @@
     // If the standard browser globals should be predefined.
     "browser": false,
     // If the Node.js environment globals should be predefined.
-    "node": false,
+    "node": true,
     // If the Rhino environment globals should be predefined.
     "rhino": false,
     // If CouchDB globals should be predefined.

--- a/lib/OptiPng.js
+++ b/lib/OptiPng.js
@@ -1,111 +1,106 @@
-/*global console*/
 var childProcess = require('child_process'),
-    Stream = require('stream').Stream,
+    Duplex = require('stream').Duplex,
     util = require('util'),
     fs = require('fs'),
-    getTemporaryFilePath = require('gettemporaryfilepath'),
+    getTempFilePath = require('gettemporaryfilepath'),
     which = require('which'),
     memoizeAsync = require('memoizeasync');
 
-function OptiPng(optiPngArgs) {
-    Stream.call(this);
-
-    this.optiPngArgs = optiPngArgs || [];
-
-    this.writable = true;
-    this.readable = true;
-
-    this.hasEnded = false;
+// a bit of boilerplate to set up our stream class
+function OptiPng(binArgs) {
+    if (!(this instanceof OptiPng))
+        return new OptiPng(binArgs);
+    Duplex.call(this);
+    this.binArgs = binArgs || []; // args to pass to cli command
 }
+util.inherits(OptiPng, Duplex);
 
-util.inherits(OptiPng, Stream);
-
-OptiPng.getBinaryPath = memoizeAsync(function (cb) {
-    which('optipng', function (err, optiPngBinaryPath) {
-        if (err) {
-            optiPngBinaryPath = require('optipng-bin').path;
+OptiPng.getBinPath = memoizeAsync(function getBinPathAsync(cb) {
+    // trying environment path first
+    which('optipng', function onWhichDone(err, binary) {
+        if (err) { // not in environment path, try in node_modules
+            binary = require('optipng-bin').path;
         }
-        if (optiPngBinaryPath) {
-            cb(null, optiPngBinaryPath);
+        if (binary) { // found somewhere
+            cb(null, binary);
         } else {
             cb(new Error('No optipng binary in PATH and optipng-bin does not provide a pre-built binary for your architecture'));
         }
     });
 });
 
-OptiPng.prototype.write = function (chunk) {
-    if (!this.writeStream) {
-        this.optiPngInputFilePath = getTemporaryFilePath({suffix: '.png'});
-        this.writeStream = fs.createWriteStream(this.optiPngInputFilePath);
-        this.writeStream.on('error', this._reportError.bind(this));
-    }
-    this.writeStream.write(chunk);
+OptiPng.prototype._read = function _read (n){
+  // don't push anything here, this is no-op unless we need to resume
+  // underlying read. We'll push into queue later.
+  if(this.rs) this.rs.resume();
 };
 
-OptiPng.prototype.end = function (chunk) {
-    if (chunk) {
-        this.write(chunk);
-    }
-    this.writeStream.end();
-    this.writable = false;
-    this.writeStream.on('close', function () {
-        OptiPng.getBinaryPath(function (err, optiPngBinaryPath) {
-            if (err) {
-                return this._reportError(err);
-            }
-
-            this.optiPngArgs.push(this.optiPngInputFilePath);
-            var optiPngProcess = childProcess.spawn(optiPngBinaryPath, this.optiPngArgs);
-            this.commandLine = optiPngBinaryPath +  (this.optiPngArgs ? ' ' + this.optiPngArgs.join(' ') : ''); // For debugging
-
-            optiPngProcess.on('error', this._reportError.bind(this));
-
-            optiPngProcess.on('exit', function (exitCode) {
-                if (exitCode > 0) {
-                    return this._reportError(new Error('The optipng process exited with a non-zero exit code: ' + exitCode));
-                }
-                this.readStream = fs.createReadStream(this.optiPngInputFilePath);
-                if (this.isPaused) {
-                    this.readStream.pause();
-                }
-                this.readStream.on('data', function (chunk) {
-                    this.emit('data', chunk);
-                }.bind(this));
-                this.readStream.on('end', function () {
-                    this.hasEnded = true;
-                    fs.unlink(this.optiPngInputFilePath, function (err) {
-                        if (err) {
-                            console.error(err.stack);
-                        }
-                    });
-                    this.emit('end');
-                }.bind(this));
-            }.bind(this));
+OptiPng.prototype._write = function _write (chunk, enc, done){
+    if (!this.ws) { // write a tempfile to give to binary
+        this.tempFile = getTempFilePath({suffix: '.png'});
+        this.ws = fs.createWriteStream(this.tempFile);
+        this.ws.on('error', function onWsErr(err){
+            this._error(err);
         }.bind(this));
-    }.bind(this));
+    }
+    this.ws.write(chunk, enc);
+    done();
 };
 
-OptiPng.prototype._reportError = function (err) {
-    if (!this.hasEnded) {
-        this.hasEnded = true;
-        this.emit('error', err);
-    }
+OptiPng.prototype.end = function end(chunk) {
+    if (chunk) { this.write(chunk); } // any final bits
+    this.ws.end();
+    this.ws.on('close', function onWsClose() {
+        // runBinary is a callback
+        OptiPng.getBinPath( runBinary );
+    });
+
+    // prebind for easy drop-in
+    var bailOut = this._error.bind(this);
+
+    var runBinary = function runBinary (err, binary){
+        if (err) { bailOut(err); }
+
+        this.binArgs.push(this.tempFile); // final arg is  the file
+        var binProcess = childProcess.spawn(binary, this.binArgs);
+
+        // format a copy of the cli string for test suite
+        this.commandLine = binary +  (this.binArgs ? ' ' + this.binArgs.join(' ') : '');
+
+        binProcess.on('error', bailOut);
+        binProcess.on('exit', onBinComplete);
+    }.bind(this);
+
+    var onBinComplete = function onBinComplete (exitCode){
+        if (exitCode > 0) {
+            return bailOut(new Error('The optipng process exited with a non-zero exit code: ' + exitCode));
+        }
+        // read back out the new file
+        this.rs = fs.createReadStream(this.tempFile);
+        this.rs.on('error', bailOut);
+        this.rs.on('data', function onRsData(chunk) {
+          // pipe it into the outgoing queue
+          var flowing = this.push(chunk);
+          // false here means output not being read, pause and wait
+          if (flowing === false) this.rs.pause();
+        }.bind(this));
+        this.rs.on('end', function onRsEnd() {
+            this.push(null); // null closes the stream
+            fs.unlink(this.tempFile, function onUnlink(err){
+                // not emitting this error since stream is done
+                if(err) console.error(err.stack);
+             });
+        }.bind(this));
+    }.bind(this);
 };
 
-// Proxy pause and resume to the underlying readStream if it has been
-// created, otherwise just keep track of the paused state:
-OptiPng.prototype.pause = function () {
-    this.isPaused = true;
-    if (this.readStream) {
-        this.readStream.pause();
-    }
+OptiPng.prototype._error = function _error(err){
+    this.push(null);
+    fs.unlink(this.tempFile, function onUnlink(err){
+        if(err) console.error(err.stack);
+    });
+    this.emit('error', err);
 };
 
-OptiPng.prototype.resume = function () {
-    this.isPaused = false;
-    if (this.readStream) {
-        this.readStream.resume();
-    }
-};
 
 module.exports = OptiPng;

--- a/test/OptiPng.js
+++ b/test/OptiPng.js
@@ -1,4 +1,4 @@
-/*global describe, it, setTimeout, __dirname*/
+/* global describe, it*/
 var expect = require('unexpected'),
     OptiPng = require('../lib/OptiPng'),
     Path = require('path'),
@@ -19,7 +19,9 @@ describe('OptiPng', function () {
                 expect(resultPngBuffer.length, 'to be less than', 152);
                 done();
             })
-            .on('error', done);
+            .on('error', function(err){
+              done(new Error('Error event was emitted when smaller file was expected.'));
+            });
     });
 
     it('should not emit data events while paused', function (done) {
@@ -58,9 +60,8 @@ describe('OptiPng', function () {
         optiPng.on('error', function (err) {
             done();
         }).on('data', function (chunk) {
+            if(chunk !== null)
             done(new Error('OptiPng emitted data when an error was expected'));
-        }).on('end', function (chunk) {
-            done(new Error('OptiPng emitted end when an error was expected'));
         });
 
         optiPng.end(new Buffer('qwvopeqwovkqvwiejvq', 'utf-8'));
@@ -71,7 +72,7 @@ describe('OptiPng', function () {
             seenError = false;
 
         optiPng.on('error', function (err) {
-            expect(optiPng.commandLine, 'to match', /optipng -vqve .*?\.png$/);
+            expect(optiPng.commandLine, 'to match', /optipng(\.exe)? -vqve .*?\.png$/);
             if (seenError) {
                 done(new Error('More than one error event was emitted'));
             } else {
@@ -79,9 +80,8 @@ describe('OptiPng', function () {
                 setTimeout(done, 100);
             }
         }).on('data', function (chunk) {
+            if (chunk !== null)
             done(new Error('OptiPng emitted data when an error was expected'));
-        }).on('end', function (chunk) {
-            done(new Error('OptiPng emitted end when an error was expected'));
         });
 
         optiPng.end(new Buffer('qwvopeqwovkqvwiejvq', 'utf-8'));


### PR DESCRIPTION
Figured out the problem, working now.

As a reminder of changes to the test suite: 

  1. Test 1 should not pass if an error is emitted, so I added a fail in that case.
  2. Stream should still be allowed to end after error, so test 3 and 4 will pass as long as emitted chunk is null. (Null chunk signals end of stream, rendering it no longer readable. I intentionally implemented pushing null as part of the cleanup whenever emitting errors.)
  3. Test 4 regex can handle optional '.exe' in binary name, so it works on windows in addition to unix.

I added node globals to .jshintrc and peppered comments all over the code.