### PR TITLE
Make `optipng-bin` an optional package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "dependencies": {
     "gettemporaryfilepath": "^1.0.0",
     "memoizeasync": "^1.1.0",
-    "optipng-bin": "^7.0.1",
     "which": "^2.0.1"
+  },
+  "optionalDependencies": {
+    "optipng-bin": "^7.0.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
We _already_ dynamically require `optipng-bin`.

`optipng-bin` will fail to install on arm64 because they have no prebuilt binaries for it.

By moving the `optipng-bin` package to be optional any failing install of `optipng-bin` will be ignored.

Users of _this_ package can then install `optipng` natively through their package manager.

As an optimisation: if a user _knows_ that `optipng` is already installed they can avoid the download of prebuilt binaries by doing `npm install optipng --omit=optional`.